### PR TITLE
Fix Marshaler, update Unmarshaler, example and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Given the name of a (signed or unsigned) integer type T that has constants
 defined, yamlenums will create a new self-contained Go source file implementing
 
 ```
-func (t T) MarshalYAML() ([]byte, error)
-func (t *T) UnmarshalYAML(unmarshal func(v interface{}) error) error
+func (t T) MarshalYAML() (interface{}, error)
+func (t *T) UnmarshalYAML(value *yaml.Node) error
 ```
 
 The file is created in the same package and directory as the package that
@@ -47,13 +47,13 @@ in the same directory will create the file `pill_yamlenums.go`, in package
 `painkiller`, containing a definition of
 
 ```
-func (r Pill) MarshalYAML() ([]byte, error)
-func (r *Pill) UnmarshalYAML(unmarshal func(v interface{}) error) error
+func (r Pill) MarshalYAML() (interface{}, error)
+func (r *Pill) UnmarshalYAML(value *yaml.Node) error
 ```
 
-`MarshalYAML` will translate the value of a `Pill` constant to the `[]byte`
+`MarshalYAML` will translate the value of a `Pill` constant to the `string`
 representation of the respective constant name, so that the call
-`yaml.Marshal(painkiller.Aspirin)` will return the bytes `[]byte("\"Aspirin\"")`.
+`yaml.Marshal(painkiller.Aspirin)` will return bytes of the string `Aspirin`.
 
 `UnmarshalYAML` performs the opposite operation;
 it unmarshals underlying bytes to a string, given the string

--- a/example/shirtsize.go
+++ b/example/shirtsize.go
@@ -80,9 +80,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	input := `{"Size":"XL", "Day":"Dimarts"}`
+	input := "size: XL\nday: Dimarts"
 	if err := yaml.NewDecoder(strings.NewReader(input)).Decode(&v); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("decoded %s as %+v\n", input, v)
+	fmt.Printf("decoded %q as %+v\n", input, v)
 }

--- a/example/shirtsize_yamlenums.go
+++ b/example/shirtsize_yamlenums.go
@@ -43,26 +43,22 @@ func init() {
 }
 
 // MarshalYAML is generated so ShirtSize satisfies yaml.Marshaler.
-func (r ShirtSize) MarshalYAML() ([]byte, error) {
+func (r ShirtSize) MarshalYAML() (interface{}, error) {
 	if s, ok := interface{}(r).(fmt.Stringer); ok {
-		return yaml.Marshal(s.String())
+		return s.String(), nil
 	}
 	s, ok := _ShirtSizeValueToName[r]
 	if !ok {
 		return nil, fmt.Errorf("invalid ShirtSize: %d", r)
 	}
-	return yaml.Marshal(s)
+	return s, nil
 }
 
 // UnmarshalYAML is generated so ShirtSize satisfies yaml.Unmarshaler.
-func (r *ShirtSize) UnmarshalYAML(unmarshal func(v interface{}) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return fmt.Errorf("ShirtSize should be a string")
-	}
-	v, ok := _ShirtSizeNameToValue[s]
+func (r *ShirtSize) UnmarshalYAML(value *yaml.Node) error {
+	v, ok := _ShirtSizeNameToValue[value.Value]
 	if !ok {
-		return fmt.Errorf("invalid ShirtSize %q", s)
+		return fmt.Errorf("invalid ShirtSize %q", value.Value)
 	}
 	*r = v
 	return nil

--- a/example/weekday_yamlenums.go
+++ b/example/weekday_yamlenums.go
@@ -46,26 +46,22 @@ func init() {
 }
 
 // MarshalYAML is generated so WeekDay satisfies yaml.Marshaler.
-func (r WeekDay) MarshalYAML() ([]byte, error) {
+func (r WeekDay) MarshalYAML() (interface{}, error) {
 	if s, ok := interface{}(r).(fmt.Stringer); ok {
-		return yaml.Marshal(s.String())
+		return s.String(), nil
 	}
 	s, ok := _WeekDayValueToName[r]
 	if !ok {
 		return nil, fmt.Errorf("invalid WeekDay: %d", r)
 	}
-	return yaml.Marshal(s)
+	return s, nil
 }
 
 // UnmarshalYAML is generated so WeekDay satisfies yaml.Unmarshaler.
-func (r *WeekDay) UnmarshalYAML(unmarshal func(v interface{}) error) error {
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return fmt.Errorf("WeekDay should be a string")
-	}
-	v, ok := _WeekDayNameToValue[s]
+func (r *WeekDay) UnmarshalYAML(value *yaml.Node) error {
+	v, ok := _WeekDayNameToValue[value.Value]
 	if !ok {
-		return fmt.Errorf("invalid WeekDay %q", s)
+		return fmt.Errorf("invalid WeekDay %q", value.Value)
 	}
 	*r = v
 	return nil

--- a/template.go
+++ b/template.go
@@ -54,26 +54,22 @@ func init() {
 }
 
 // MarshalYAML is generated so {{$typename}} satisfies yaml.Marshaler.
-func (r {{$typename}}) MarshalYAML() ([]byte, error) {
+func (r {{$typename}}) MarshalYAML() (interface{}, error) {
     if s, ok := interface{}(r).(fmt.Stringer); ok {
-        return yaml.Marshal(s.String())
+        return s.String(), nil
     }
     s, ok := _{{$typename}}ValueToName[r]
     if !ok {
         return nil, fmt.Errorf("invalid {{$typename}}: %d", r)
     }
-    return yaml.Marshal(s)
+    return s, nil
 }
 
 // UnmarshalYAML is generated so {{$typename}} satisfies yaml.Unmarshaler.
-func (r *{{$typename}}) UnmarshalYAML(unmarshal func(v interface{}) error) error {
-    var s string
-	if err := unmarshal(&s); err != nil {
-		return fmt.Errorf("{{$typename}} should be a string")
-	}
-	v, ok := _{{$typename}}NameToValue[s]
+func (r *{{$typename}}) UnmarshalYAML(value *yaml.Node) error {
+	v, ok := _{{$typename}}NameToValue[value.Value]
 	if !ok {
-		return fmt.Errorf("invalid {{$typename}} %q", s)
+		return fmt.Errorf("invalid {{$typename}} %q", value.Value)
 	}
 	*r = v
 	return nil

--- a/yamlenums.go
+++ b/yamlenums.go
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 // YAMLenums is a tool to automate the creation of methods that satisfy the
-// fmt.Stringer, yaml.Marshaler and yaml.Unmarshaler interfaces.
+// yaml.Marshaler and yaml.Unmarshaler interfaces.
 // Given the name of a (signed or unsigned) integer type T that has constants
 // defined, yamlenums will create a new self-contained Go source file implementing
 //
-//  func (t T) String() string
-//  func (t T) MarshalYAML() ([]byte, error)
-//  func (t *T) UnmarshalYAML([]byte) error
+//  func (t T) MarshalYAML() (interface{}, error)
+//  func (t *T) UnmarshalYAML(value *yaml.Node) error
 //
 // The file is created in the same package and directory as the package that defines T.
 // It has helpful defaults designed for use with go generate.
@@ -48,13 +47,12 @@
 // in the same directory will create the file pill_yamlenums.go, in package painkiller,
 // containing a definition of
 //
-//  func (r Pill) String() string
-//  func (r Pill) MarshalYAML() ([]byte, error)
-//  func (r *Pill) UnmarshalYAML([]byte) error
+//  func (r Pill) MarshalYAML() (interface{}, error)
+//  func (r *Pill) UnmarshalYAML(value *yaml.Node) error
 //
 // That method will translate the value of a Pill constant to the string representation
-// of the respective constant name, so that the call fmt.Print(painkiller.Aspirin) will
-// print the string "Aspirin".
+// of the respective constant name, so that the painkiller.Aspirin will be marshaled to
+// YAML as the string Aspirin and can be unmarshaled from that string.
 //
 // Typically this process would be run using go generate, like this:
 //


### PR DESCRIPTION
1. Adapted the `MarshalYAML()` to match the [Marshaler interface in go-yaml](https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/yaml.go#L50), otherwise it was not called.
2. Updated the `UnmarshalYAML()` to match the current [Unmarshaler interface in go-yaml](https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/yaml.go#L36), because used implementation is [marked as obsolete](https://github.com/go-yaml/yaml/blob/f6f7691b1fdeb513f56608cd2c32c51f8194bf51/yaml.go#L40).
3. Fixed the example code by removing the remaining JSON from it.
4. Updated README.md and some comments to be more consistent with this application.
